### PR TITLE
Encode full email subject for mailto link

### DIFF
--- a/script.js
+++ b/script.js
@@ -36,10 +36,8 @@
 
       function updateEmailSubject() {
         const systemName = q1Input.value.trim() || '[Systemnavn]';
-        emailLink.href =
-          'mailto:sos@slagelse.dk?subject=' +
-          encodeURIComponent(systemName) +
-          ' - Risikovurdering';
+        const subject = encodeURIComponent(`${systemName} - Risikovurdering`);
+        emailLink.href = `mailto:sos@slagelse.dk?subject=${subject}`;
       }
 
       q1Input.addEventListener('input', updateEmailSubject);


### PR DESCRIPTION
## Summary
- URI-encode the entire mailto subject line

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684b2cce7ed4832b854d3817a49d548c