### PR TITLE
Add sanitized answer preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Dette repository indeholder en simpel HTML-formular til risikovurdering af IT-sy
 
 1. Åbn `index.html` i din browser.
 2. Udfyld felterne med oplysninger om dit IT-system.
-3. Klik på **Download svar** for at hente en fil med dine besvarelser.
-4. Vedlæg den downloadede fil i en e-mail til de relevante parter.
+3. Klik på **Vis svar** for at få vist en læsevenlig oversigt, som automatisk skjuler følsomme felter. Teksten kan kopieres direkte.
+4. Klik på **Download svar** for at hente alle besvarelser som en JSON-fil.
+5. Vedlæg den downloadede fil i en e-mail til de relevante parter.
 
 ## Krav
 

--- a/index.html
+++ b/index.html
@@ -427,7 +427,9 @@
 
 
 
+    <button type="button" class="mail-button" onclick="showSanitizedAnswers()">Vis svar</button>
     <button type="button" class="mail-button" onclick="downloadAnswers()">Download svar</button>
+    <textarea id="answerPreview" readonly style="display:none; width:100%; height:300px; margin-top:1rem;"></textarea>
   </form>
   <script src="script.js"></script>
   </div>

--- a/script.js
+++ b/script.js
@@ -1,4 +1,4 @@
-    function downloadAnswers() {
+    function getFormData() {
       const form = document.getElementById("riskForm");
       const formData = new FormData(form);
       const data = {};
@@ -13,11 +13,56 @@
           data[key] = value;
         }
       }
+      return data;
+    }
+
+    function downloadAnswers() {
+      const data = getFormData();
       const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
       const link = document.createElement("a");
       link.href = URL.createObjectURL(blob);
       link.download = "risikovurdering.json";
       link.click();
+    }
+
+    function getQuestionLabel(key) {
+      const field = document.querySelector(`[name="${key}"]`);
+      if (field) {
+        const wrapper = field.closest('.question');
+        if (wrapper) {
+          const heading = wrapper.querySelector('h3');
+          if (heading) {
+            return heading.textContent.trim();
+          }
+        }
+      }
+      return key;
+    }
+
+    function showSanitizedAnswers() {
+      const data = getFormData();
+      const sensitiveFields = ['q1', 'q2', 'q3', 'q4'];
+
+      sensitiveFields.forEach(f => {
+        delete data[f];
+        delete data[`${f}_other`];
+      });
+
+      let text = '';
+      for (const [key, value] of Object.entries(data)) {
+        if (sensitiveFields.some(f => key.startsWith(f))) continue;
+        if (value === '') continue;
+        const label = getQuestionLabel(key);
+        if (Array.isArray(value)) {
+          text += `${label}: ${value.join('; ')}\n`;
+        } else {
+          text += `${label}: ${value}\n`;
+        }
+      }
+
+      const preview = document.getElementById('answerPreview');
+      preview.value = text.trim();
+      preview.style.display = 'block';
     }
 
     document.addEventListener('DOMContentLoaded', function () {


### PR DESCRIPTION
## Summary
- add a "Vis svar" button and preview area to show sanitized answers
- skip sensitive fields when showing this preview
- update script with helper functions for data extraction and sanitization
- describe new feature in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684b35529000832bbddc69be78ca9388